### PR TITLE
Add crop to support takeElement function

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ The wrapper uses [pixelmatch](https://github.com/mapbox/pixelmatch) which is sim
   }
   ```
 
+## Dependencies
+
+In order to use `takeElement(elementCssPath)` function you will need to
+install imagemagick as we crop the full page screenshot in order to have
+an image of a given element.
+
+On Ubuntu
+
+`$ apt-get install imagemagick`
+
+On Mac OS X
+
+`$ brew install imagemagick`
+
+On CentOS
+
+`$ yum install imagemagick`
+
 ## Writing a test
 
 - Writing a visual test is composed by 3 steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3451,6 +3451,11 @@
       "dev": true,
       "optional": true
     },
+    "bluebird": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4053,6 +4058,18 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "easyimage": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/easyimage/-/easyimage-3.1.1.tgz",
+      "integrity": "sha512-W9QFelSdXjDK7ja0+jkDKwtJSrSggN/GDzgDY4+QguF9YElVkcbMZp64H8OinBI0ajow/h2p/MukdFOzpH1Mng==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "mkdirp": "^0.5.0",
+        "nanoid": "^1.0.2",
+        "tslib": "^1.8.1",
+        "typescript": "^3.3.0"
       }
     },
     "ecc-jsbn": {
@@ -7997,7 +8014,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -8005,8 +8021,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -8028,6 +8043,11 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.3.4.tgz",
+      "integrity": "sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9985,8 +10005,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -10011,6 +10030,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typescript": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw=="
     },
     "uglify-js": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "homepage": "https://github.com/uktrade/wdio-image-diff#readme",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
+    "easyimage": "^3.1.1",
     "fs": "0.0.1-security",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.1.2",

--- a/src/commands/save-element-screenshot.js
+++ b/src/commands/save-element-screenshot.js
@@ -1,8 +1,33 @@
 import path from '../config/config'
+import { crop } from 'easyimage'
 
 const saveElementScreenshot = async (browser, testName, elementCssPath) => {
+  const imgPath = path.image.comparison(testName)
+
   const element = await browser.$(elementCssPath)
-  return element.saveScreenshot(path.image.comparison(testName))
+  const elementSize = await element.getSize()
+  const elementLocation = await element.getLocation()
+
+  await browser.saveScreenshot(imgPath)
+
+  return cropImage(elementSize.width, elementSize.height, elementLocation.x, elementLocation.y, imgPath)
+}
+
+const cropImage = async (elemenetWidth, elementHeight, elementX, elementY, imgPath) => {
+  await crop(
+    {
+      src: imgPath,
+      dst: imgPath,
+      cropWidth: elemenetWidth,
+      cropHeight: elementHeight,
+      x: elementX,
+      y: elementY,
+      gravity: 'North-West'
+    },
+    err => {
+      if (err) throw err
+    }
+  )
 }
 
 export default saveElementScreenshot


### PR DESCRIPTION
Since `element.saveScreenshot` exposed by webDriver is not supported in most browsers, we need to crop a full page screenshot on a given elements location to support screenshots for a given element in the dom.