### PR TITLE
Improve cli update

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@ import arg from 'arg'
 import fs from 'fs-extra'
 
 import path from './config'
+import { readDir } from './utils'
 
 const parseArgumentsIntoOptions = rawArgs => {
  const args = arg(
@@ -23,6 +24,12 @@ export function cli(args) {
  let options = parseArgumentsIntoOptions(args)
 
  if (options.updateBaseline) {
-   fs.copySync(path.dir.comparison, path.dir.baseline)
+   // Only update image if it failed the comparison
+   const filesToUpdate = readDir(path.dir.diff)
+   if (filesToUpdate) {
+     filesToUpdate.forEach(file => {
+       fs.copySync(path.dir.comparison + '/' + file, path.dir.baseline + '/' + file)
+     })
+   }
  }
 }

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -1,9 +1,10 @@
 import { cli } from './cli'
-import { copySync } from 'fs-extra'
+import { copySync, readdirSync } from 'fs-extra'
 
 jest.mock('fs-extra', () => ({
   ...jest.requireActual('fs-extra'),
   copySync: jest.fn(),
+  readdirSync: jest.fn(),
 }))
 
 describe('Cli', () => {
@@ -18,8 +19,10 @@ describe('Cli', () => {
     })
 
     it('should update baseline images if argument is specified', () => {
+      readdirSync.mockReturnValue(['File1.png', 'File2.png'])
+
       cli(['--dummyArg1', '--dummyArg2', '-u'])
-      expect(copySync).toHaveBeenCalledTimes(1)
+      expect(copySync).toHaveBeenCalledTimes(2)
     })
 
     it('should ignore the first 2 arguments', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import createDir from './utils'
+import { createDir, cleanDir } from './utils'
 import { createReport } from './reporter'
 import imageDiff from './commands/image-diff'
 import path from './config'
@@ -29,6 +29,10 @@ class WdioImage {
     Object.values(path.dir).forEach(dir => {
       createDir(dir)
     })
+
+    // Clean diff and comparison subfolders
+    cleanDir(path.dir.comparison)
+    cleanDir(path.dir.diff)
   }
 
   take() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 
 const createDir = dir => {
   if (!fs.existsSync(dir)) {
@@ -6,4 +6,14 @@ const createDir = dir => {
   }
 }
 
-export default createDir
+const cleanDir = dir => {
+  if (fs.existsSync(dir)) {
+    fs.emptyDirSync(dir)
+  }
+}
+
+const readDir = dir => {
+  return fs.readdirSync(dir)
+}
+
+export { createDir, cleanDir, readDir }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,36 +1,57 @@
-import createDir from './utils'
-import fs from 'fs'
+import { createDir, cleanDir } from './utils'
+import { existsSync, mkdirSync, emptyDirSync, readdirSync } from 'fs-extra'
 
-jest.mock('fs', () => {
-  return {
-    existsSync: jest.fn(),
-    mkdirSync: jest.fn(),
-  }
-})
+jest.mock('fs-extra', () => ({
+  ...jest.requireActual('fs-extra'),
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  emptyDirSync: jest.fn(),
+  readdirSync: jest.fn(),
+}))
 
 describe('Utils', () => {
   const args = 'some/path'
+  const sampleFiles = ['test.png', 'test1.png']
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  describe('create dir', () => {
+  describe('Create dir', () => {
     it('should trigger create directory function when path doesn\'t exist', () => {
-      fs.existsSync.mockReturnValue(false)
+      existsSync.mockReturnValue(false)
       
       createDir(args)
-      expect(fs.existsSync).toHaveBeenCalledTimes(1)
-      expect(fs.mkdirSync).toHaveBeenCalledTimes(1)
-      expect(fs.mkdirSync).toBeCalledWith(args)
+      expect(existsSync).toHaveBeenCalledTimes(1)
+      expect(mkdirSync).toHaveBeenCalledTimes(1)
+      expect(mkdirSync).toBeCalledWith(args)
     })
   
     it('should not trigger create directory function when path exists', () => {
-      fs.existsSync.mockReturnValue(true)
+      existsSync.mockReturnValue(true)
       
       createDir(args)
-      expect(fs.existsSync).toHaveBeenCalledTimes(1)
-      expect(fs.mkdirSync).toHaveBeenCalledTimes(0)
+      expect(existsSync).toHaveBeenCalledTimes(1)
+      expect(mkdirSync).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('Clean dir', () => {
+    it('should trigger clean directory function when path exists', () => {
+      existsSync.mockReturnValue(true)
+      readdirSync.mockReturnValue(sampleFiles)
+      
+      cleanDir(args)
+      expect(existsSync).toHaveBeenCalledTimes(1)
+      expect(emptyDirSync).toHaveBeenCalledTimes(1)
+    })
+  
+    it('should not trigger clean directory function when path doesn\'t exist', () => {
+      existsSync.mockReturnValue(false)
+      
+      cleanDir(args)
+      expect(existsSync).toHaveBeenCalledTimes(1)
+      expect(emptyDirSync).toHaveBeenCalledTimes(0)
     })
   })
 })


### PR DESCRIPTION
Made the update more robust to ensure it only updates images to the baseline folder if they actually failed the comparison check.

This solves the problem where git was accusing multiple image updates when running the `wdio-image-diff -u` command. This is due to images with 1-2 pixel differences from baseline but not failing the comparison check (as expected) being different than the actual baseline.

Also made some improvements in consistency and started using `fs-extra` in all files rather than a mix of it along with the native `fs` package.