### PR TITLE
Add console for update cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6487,6 +6487,14 @@
       "dev": true,
       "requires": {
         "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
       }
     },
     "cli-width": {
@@ -6574,10 +6582,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "arg": "^4.1.1",
+    "colors": "^1.4.0",
     "easyimage": "^3.1.1",
     "esm": "^3.2.25",
     "fs": "0.0.1-security",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,5 @@
 import arg from 'arg'
+import colors from 'colors/safe'
 import fs from 'fs-extra'
 
 import path from './config'
@@ -22,14 +23,17 @@ const parseArgumentsIntoOptions = rawArgs => {
 
 export function cli(args) {
  let options = parseArgumentsIntoOptions(args)
-
  if (options.updateBaseline) {
    // Only update image if it failed the comparison
    const filesToUpdate = readDir(path.dir.diff)
    if (filesToUpdate) {
      filesToUpdate.forEach(file => {
        fs.copySync(path.dir.comparison + '/' + file, path.dir.baseline + '/' + file)
+       console.log(colors.green(`Updated baseline image ${file}`))
      })
+   } else {
+    const output = 'No baselines to be updated. Make sure to run the visual tests before running update.'
+    console.log(colors.yellow(output))
    }
  }
 }

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -1,11 +1,14 @@
 import { cli } from './cli'
 import { copySync, readdirSync } from 'fs-extra'
+import colors from 'colors/safe'
 
 jest.mock('fs-extra', () => ({
   ...jest.requireActual('fs-extra'),
   copySync: jest.fn(),
   readdirSync: jest.fn(),
 }))
+
+console.log = jest.fn()
 
 describe('Cli', () => {
   afterEach(() => {
@@ -19,15 +22,26 @@ describe('Cli', () => {
     })
 
     it('should update baseline images if argument is specified', () => {
-      readdirSync.mockReturnValue(['File1.png', 'File2.png'])
+      const files = ['File1.png', 'File2.png']
+      readdirSync.mockReturnValue(files)
 
       cli(['--dummyArg1', '--dummyArg2', '-u'])
       expect(copySync).toHaveBeenCalledTimes(2)
+      expect(console.log.mock.calls[0][0]).toBe(colors.green(`Updated baseline image ${files[0]}`))
+      expect(console.log.mock.calls[1][0]).toBe(colors.green(`Updated baseline image ${files[1]}`))
     })
 
     it('should ignore the first 2 arguments', () => {
       cli(['-u', '-u'])
       expect(copySync).toHaveBeenCalledTimes(0)
+    })
+
+    it('should output message when no images to be updated', () => {
+      readdirSync.mockReturnValue()
+      cli(['--dummyArg1', '--dummyArg2', '-u'])
+
+      const expectedOutput = 'No baselines to be updated. Make sure to run the visual tests before running update.'
+      expect(console.log.mock.calls[0][0]).toBe(colors.yellow(expectedOutput))
     })
   })
 })


### PR DESCRIPTION
The intent of this PR is to add some console output when interacting with the update option in the cli. In the near future we will add an option to the test execution to automatically update the baselines.